### PR TITLE
fix: remove Facebook and YouTube from sidebar

### DIFF
--- a/src/_includes/partials/sidebar.njk
+++ b/src/_includes/partials/sidebar.njk
@@ -29,10 +29,8 @@
 <div class="uk-panel uk-margin">
     <h3 class="uk-panel-title">Social Links</h3>
     <a href="https://github.com/seank-com"><span uk-icon="github"></span></a>
-    <a href="https://www.facebook.com/therenaissancehacker"><span uk-icon="facebook"></span></a>
     <a href="https://www.instagram.com/seank_com/"><span uk-icon="instagram"></span></a>
     <a href="https://www.linkedin.com/in/sean-d-kelly/"><span uk-icon="linkedin"></span></a>
     <a href="https://twitter.com/seank"><span uk-icon="twitter"></span></a>
-    <a href="https://www.youtube.com/channel/UC_Sz_dtg8TYMChxmR1qgVzw"><span uk-icon="youtube"></span></a>
 </div>
 


### PR DESCRIPTION
Removes the Facebook and YouTube social links from the sidebar. GitHub, Instagram, LinkedIn, and Twitter remain.